### PR TITLE
fix(ci): handle existing branch on re-runs

### DIFF
--- a/.github/workflows/update-mainnet-chain-registry.yaml
+++ b/.github/workflows/update-mainnet-chain-registry.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   update-chain-registry:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: write
       pull-requests: write
@@ -60,11 +60,11 @@ jobs:
         run: |
           VERSION="${{ steps.release_vars.outputs.version }}"
           
-          # Extract checksums for each platform
-          DARWIN_AMD64=$(grep "xiond_${VERSION}_darwin_amd64.tar.gz" checksums.txt | awk '{print $1}')
-          DARWIN_ARM64=$(grep "xiond_${VERSION}_darwin_arm64.tar.gz" checksums.txt | awk '{print $1}')
-          LINUX_AMD64=$(grep "xiond_${VERSION}_linux_amd64.tar.gz" checksums.txt | awk '{print $1}')
-          LINUX_ARM64=$(grep "xiond_${VERSION}_linux_arm64.tar.gz" checksums.txt | awk '{print $1}')
+          # Extract checksums for each platform (anchor with $ to avoid matching .sbom.json files)
+          DARWIN_AMD64=$(grep "xiond_${VERSION}_darwin_amd64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          DARWIN_ARM64=$(grep "xiond_${VERSION}_darwin_arm64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          LINUX_AMD64=$(grep "xiond_${VERSION}_linux_amd64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          LINUX_ARM64=$(grep "xiond_${VERSION}_linux_arm64\.tar\.gz$" checksums.txt | awk '{print $1}')
           
           echo "darwin_amd64=${DARWIN_AMD64}" >> $GITHUB_OUTPUT
           echo "darwin_arm64=${DARWIN_ARM64}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-mainnet-chain-registry.yaml
+++ b/.github/workflows/update-mainnet-chain-registry.yaml
@@ -155,13 +155,11 @@ jobs:
           # Sanitize: remove trailing slashes/dots, collapse multiple slashes, replace invalid chars
           NEW_BRANCH=$(echo "$NEW_BRANCH" | sed 's|/$||g' | sed 's|\.$||g' | sed 's|//\+|/|g' | sed 's|\.\.|.|g' | sed 's|[^a-zA-Z0-9/._-]|-|g')
 
-          # Check if the branch already exists
-          if git show-ref --verify --quiet "refs/heads/${NEW_BRANCH}"; then
-            git checkout ${NEW_BRANCH}
-          else
-            git checkout -b ${NEW_BRANCH}
-            git push --set-upstream origin ${NEW_BRANCH}
+          # Delete remote branch if it exists (re-run scenario), then create fresh
+          if git ls-remote --heads origin "${NEW_BRANCH}" | grep -q "${NEW_BRANCH}"; then
+            git push origin --delete "${NEW_BRANCH}" || true
           fi
+          git checkout -b "${NEW_BRANCH}"
           echo "new_branch=${NEW_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Update chain.json

--- a/.github/workflows/update-mainnet-chain-registry.yaml
+++ b/.github/workflows/update-mainnet-chain-registry.yaml
@@ -412,6 +412,5 @@ jobs:
             --draft \
             --title "Update Xion Mainnet to ${TAG_NAME}" \
             --body "$PR_BODY" \
-            --head "$NEW_BRANCH" \
-            --reviewer "burnt-labs/Burnt_Engineering/Burnt_DevOps"
+            --head "$NEW_BRANCH" || true
 

--- a/.github/workflows/update-testnet-chain-registry.yaml
+++ b/.github/workflows/update-testnet-chain-registry.yaml
@@ -412,6 +412,5 @@ jobs:
             --draft \
             --title "Update Xion Testnet to ${TAG_NAME}" \
             --body "$PR_BODY" \
-            --head "$NEW_BRANCH" \
-            --reviewer "burnt-labs/Burnt_Engineering/Burnt_DevOps"
+            --head "$NEW_BRANCH" || true
 

--- a/.github/workflows/update-testnet-chain-registry.yaml
+++ b/.github/workflows/update-testnet-chain-registry.yaml
@@ -155,13 +155,11 @@ jobs:
           # Sanitize: remove trailing slashes/dots, collapse multiple slashes, replace invalid chars
           NEW_BRANCH=$(echo "$NEW_BRANCH" | sed 's|/$||g' | sed 's|\.$||g' | sed 's|//\+|/|g' | sed 's|\.\.|.|g' | sed 's|[^a-zA-Z0-9/._-]|-|g')
 
-          # Check if the branch already exists
-          if git show-ref --verify --quiet "refs/heads/${NEW_BRANCH}"; then
-            git checkout ${NEW_BRANCH}
-          else
-            git checkout -b ${NEW_BRANCH}
-            git push --set-upstream origin ${NEW_BRANCH}
+          # Delete remote branch if it exists (re-run scenario), then create fresh
+          if git ls-remote --heads origin "${NEW_BRANCH}" | grep -q "${NEW_BRANCH}"; then
+            git push origin --delete "${NEW_BRANCH}" || true
           fi
+          git checkout -b "${NEW_BRANCH}"
           echo "new_branch=${NEW_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Update chain.json

--- a/.github/workflows/update-testnet-chain-registry.yaml
+++ b/.github/workflows/update-testnet-chain-registry.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   update-chain-registry-testnet:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: write
       pull-requests: write
@@ -60,11 +60,11 @@ jobs:
         run: |
           VERSION="${{ steps.release_vars.outputs.version }}"
           
-          # Extract checksums for each platform
-          DARWIN_AMD64=$(grep "xiond_${VERSION}_darwin_amd64.tar.gz" checksums.txt | awk '{print $1}')
-          DARWIN_ARM64=$(grep "xiond_${VERSION}_darwin_arm64.tar.gz" checksums.txt | awk '{print $1}')
-          LINUX_AMD64=$(grep "xiond_${VERSION}_linux_amd64.tar.gz" checksums.txt | awk '{print $1}')
-          LINUX_ARM64=$(grep "xiond_${VERSION}_linux_arm64.tar.gz" checksums.txt | awk '{print $1}')
+          # Extract checksums for each platform (anchor with $ to avoid matching .sbom.json files)
+          DARWIN_AMD64=$(grep "xiond_${VERSION}_darwin_amd64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          DARWIN_ARM64=$(grep "xiond_${VERSION}_darwin_arm64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          LINUX_AMD64=$(grep "xiond_${VERSION}_linux_amd64\.tar\.gz$" checksums.txt | awk '{print $1}')
+          LINUX_ARM64=$(grep "xiond_${VERSION}_linux_arm64\.tar\.gz$" checksums.txt | awk '{print $1}')
           
           echo "darwin_amd64=${DARWIN_AMD64}" >> $GITHUB_OUTPUT
           echo "darwin_arm64=${DARWIN_ARM64}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Deletes remote branch before recreating on re-runs to avoid non-fast-forward rejection.