### PR TITLE
fix(ci): push branch to remote before commit action

### DIFF
--- a/.github/workflows/update-mainnet-chain-registry.yaml
+++ b/.github/workflows/update-mainnet-chain-registry.yaml
@@ -160,6 +160,7 @@ jobs:
             git push origin --delete "${NEW_BRANCH}" || true
           fi
           git checkout -b "${NEW_BRANCH}"
+          git push --set-upstream origin "${NEW_BRANCH}"
           echo "new_branch=${NEW_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Update chain.json

--- a/.github/workflows/update-testnet-chain-registry.yaml
+++ b/.github/workflows/update-testnet-chain-registry.yaml
@@ -160,6 +160,7 @@ jobs:
             git push origin --delete "${NEW_BRANCH}" || true
           fi
           git checkout -b "${NEW_BRANCH}"
+          git push --set-upstream origin "${NEW_BRANCH}"
           echo "new_branch=${NEW_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Update chain.json


### PR DESCRIPTION
The github-commit-sign action needs the branch to exist on remote.