### PR TITLE
fix(ui): move global body styles out of scoped App.vue styles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,15 +54,6 @@ onMounted(fetchjsonfiles);
 </template>
 
 <style scoped>
-body {
-  font-family: arial, sans-serif;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  min-height: 100vh;
-  margin: 0;
-}
-
 ul {
   max-width: 100%;
   overflow-wrap: break-word;

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -29,7 +29,6 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  font-family: Arial, sans-serif;
 }
 
 h1 {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -24,10 +24,12 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  font-family: Arial, sans-serif;
 }
 
 h1 {


### PR DESCRIPTION
The body selector in App.vue was inside a scoped style block, so Vue
transformed it into a selector requiring the component's scope attribute.
Since the document body does not receive that attribute, the styles never
matched.

This change moves the document-level body styles to src/assets/main.css.

Fixes:
- top alignment of the asset list
- intended column layout
- intended global font family